### PR TITLE
Adjust GCP example to reflect default aud change

### DIFF
--- a/gcp/gcp.tf
+++ b/gcp/gcp.tf
@@ -64,7 +64,12 @@ resource "google_iam_workload_identity_pool_provider" "tfc_provider" {
   }
   oidc {
     issuer_uri        = "https://${var.tfc_hostname}"
-    allowed_audiences = [var.tfc_gcp_audience]
+    # The default audience format used by TFC is of the form:
+    # //iam.googleapis.com/projects/{project number}/locations/global/workloadIdentityPools/{pool ID}/providers/{provider ID}
+    # which matches with the default accepted audience format on GCP.
+    #
+    # Uncomment the line below if you are specifying a custom value for the audience instead of using the default audience.
+    # allowed_audiences = [var.tfc_gcp_audience]
   }
   attribute_condition = "assertion.sub.startsWith(\"${local.non_project_sub_check}\") || assertion.sub.startsWith(\"${local.project_sub_check}\")"
 }

--- a/gcp/vars.tf
+++ b/gcp/vars.tf
@@ -3,8 +3,8 @@
 
 variable "tfc_gcp_audience" {
   type        = string
-  default     = "gcp.workload.identity"
-  description = "The audience value to use in run identity tokens"
+  default     = ""
+  description = "The audience value to use in run identity tokens if the default audience value is not desired."
 }
 
 variable "tfc_hostname" {


### PR DESCRIPTION
Modifies the example GCP configuration to use the default audience in GCP, and to provide instructions around when a user should uncomment the `allowed_audiences` property.