### PR TITLE
Add .terraform.lock.hcl to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 crash.log
 
 terraform.tfvars
+*.terraform.lock.hcl


### PR DESCRIPTION
Adds .terraform.lock.hcl to .gitignore. These lock files are generated when running Terraform but should not be committed to the repo.