### PR TITLE
Default to using TFC_GCP_WORKLOAD_PROVIDER_NAME in GCP example

### DIFF
--- a/gcp/tfc-workspace.tf
+++ b/gcp/tfc-workspace.tf
@@ -28,35 +28,55 @@ resource "tfe_variable" "enable_gcp_provider_auth" {
   description = "Enable the Workload Identity integration for GCP."
 }
 
-resource "tfe_variable" "tfc_gcp_project_number" {
+# The provider name contains the project number, pool ID,
+# and provider ID. This information can be supplied using
+# this TFC_GCP_WORKLOAD_PROVIDER_NAME variable, or using
+# the separate TFC_GCP_PROJECT_NUMBER, TFC_GCP_WORKLOAD_POOL_ID,
+# and TFC_GCP_WORKLOAD_PROVIDER_ID variables below if desired.
+#
+resource "tfe_variable" "tfc_gcp_workload_provider_name" {
   workspace_id = tfe_workspace.my_workspace.id
 
-  key      = "TFC_GCP_PROJECT_NUMBER"
-  value    = data.google_project.project.number
+  key      = "TFC_GCP_WORKLOAD_PROVIDER_NAME"
+  value    =  google_iam_workload_identity_pool_provider.tfc_provider.name
   category = "env"
 
-  description = "The numeric identifier of the GCP project"
+  description = "The workload provider name to authenticate against."
 }
 
-resource "tfe_variable" "tfc_gcp_workload_pool_id" {
-  workspace_id = tfe_workspace.my_workspace.id
+# Uncomment the following variables and comment out
+# tfc_gcp_workload_provider_name if you wish to supply this
+# information in separate variables instead!
 
-  key      = "TFC_GCP_WORKLOAD_POOL_ID"
-  value    = google_iam_workload_identity_pool.tfc_pool.workload_identity_pool_id
-  category = "env"
+# resource "tfe_variable" "tfc_gcp_project_number" {
+#   workspace_id = tfe_workspace.my_workspace.id
 
-  description = "The ID of the workload identity pool."
-}
+#   key      = "TFC_GCP_PROJECT_NUMBER"
+#   value    = data.google_project.project.number
+#   category = "env"
 
-resource "tfe_variable" "tfc_gcp_workload_provider_id" {
-  workspace_id = tfe_workspace.my_workspace.id
+#   description = "The numeric identifier of the GCP project"
+# }
 
-  key      = "TFC_GCP_WORKLOAD_PROVIDER_ID"
-  value    = google_iam_workload_identity_pool_provider.tfc_provider.workload_identity_pool_provider_id
-  category = "env"
+# resource "tfe_variable" "tfc_gcp_workload_pool_id" {
+#   workspace_id = tfe_workspace.my_workspace.id
 
-  description = "The ID of the workload identity pool provider."
-}
+#   key      = "TFC_GCP_WORKLOAD_POOL_ID"
+#   value    = google_iam_workload_identity_pool.tfc_pool.workload_identity_pool_id
+#   category = "env"
+
+#   description = "The ID of the workload identity pool."
+# }
+
+# resource "tfe_variable" "tfc_gcp_workload_provider_id" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_GCP_WORKLOAD_PROVIDER_ID"
+#   value    = google_iam_workload_identity_pool_provider.tfc_provider.workload_identity_pool_provider_id
+#   category = "env"
+
+#   description = "The ID of the workload identity pool provider."
+# }
 
 resource "tfe_variable" "tfc_gcp_service_account_email" {
   workspace_id = tfe_workspace.my_workspace.id


### PR DESCRIPTION
Default to using `TFC_GCP_WORKLOAD_PROVIDER_NAME` for the GCP dynamic credentials example.

This variable is meant to contain the same information as `TFC_GCP_PROJECT_NUMBER`, `TFC_GCP_WORKLOAD_POOL_ID` and `TFC_GCP_WORKLOAD_PROVIDER_ID` in the format described [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider#name), and can be used in place of them.

The separate values have been kept as users may wish to continue providing these values separately, but they have now been commented out by default.