### PR TITLE
Fix GCP vault-backed example IAM permissions issue

### DIFF
--- a/vault-backed/gcp/gcp.tf
+++ b/vault-backed/gcp/gcp.tf
@@ -1,11 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# Data source used to get the project id programmatically.
-#
-# https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project
-data "google_project" "current" {
+provider "google" {
+  project = var.gcp_project_id
 }
+
 
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account
 resource "google_service_account" "secrets_engine" {
@@ -18,8 +17,13 @@ resource "google_service_account" "secrets_engine" {
 #
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam
 resource "google_project_iam_member" "secrets_engine" {
-  project = data.google_project.current.project_id
-  role    = "roles/editor"
+  for_each = toset([
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountKeyAdmin",
+    "roles/resourcemanager.projectIamAdmin"
+  ])
+  project = var.gcp_project_id
+  role    = each.value
   member  = "serviceAccount:${google_service_account.secrets_engine.email}"
 }
 

--- a/vault-backed/gcp/vars.tf
+++ b/vault-backed/gcp/vars.tf
@@ -50,3 +50,8 @@ variable "tfc_vault_audience" {
   default     = "vault.workload.identity"
   description = "The audience value to use in run identity tokens"
 }
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The ID for your GCP project"
+}

--- a/vault-backed/gcp/vault.tf
+++ b/vault-backed/gcp/vault.tf
@@ -80,6 +80,11 @@ resource "vault_gcp_secret_backend" "gcp_secret_backend" {
   # WARNING - These values will be written in plaintext in the statefiles for this configuration. 
   # Protect the statefiles for this configuration accordingly!
   credentials = base64decode(google_service_account_key.secrets_engine_key.private_key)
+
+  depends_on = [
+    google_service_account.secrets_engine,
+    google_project_iam_member.secrets_engine
+  ]
 }
 
 # 
@@ -89,14 +94,19 @@ resource "vault_gcp_secret_roleset" "gcp_secret_roleset" {
   backend      = vault_gcp_secret_backend.gcp_secret_backend.path
   roleset      = "project_viewer"
   secret_type  = "access_token"
-  project      = data.google_project.current.project_id
+  project      = var.gcp_project_id
   token_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
   binding {
-    resource = "//cloudresourcemanager.googleapis.com/projects/${data.google_project.current.project_id}"
+    resource = "//cloudresourcemanager.googleapis.com/projects/${var.gcp_project_id}"
 
     roles = [
       "roles/viewer",
     ]
   }
+
+  depends_on = [
+    google_service_account.secrets_engine,
+    google_project_iam_member.secrets_engine
+  ]
 }


### PR DESCRIPTION
Fix IAM permission issue below:

│ Error: Error writing GCP Secrets backend roleset “gcp/roleset/project_viewer”: Error making API request.
│
│ Namespace: admin/
│ URL: PUT https://xxxx.hashicorp.cloud:8200/v1/gcp/roleset/project_viewer
│ Code: 400. Errors:
│
│ * unable to set IAM policy for resource “[//cloudresourcemanager.googleapis.com/projects/xxx](https://hashicorp.slack.com//cloudresourcemanager.googleapis.com/projects/xxx)”: unable to set policy: googleapi: Error 403: Policy update access denied.
│
│   with vault_gcp_secret_roleset.gcp_secret_roleset,
│   on vault.tf line 89, in resource “vault_gcp_secret_roleset” “gcp_secret_roleset”:
│   89: resource “vault_gcp_secret_roleset” “gcp_secret_roleset” {