### PR TITLE
Add example var / explanations for multiple configuration support

### DIFF
--- a/aws/tfc-workspace.tf
+++ b/aws/tfc-workspace.tf
@@ -49,3 +49,28 @@ resource "tfe_variable" "tfc_aws_role_arn" {
 
 #   description = "The value to use as the audience claim in run identity tokens"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration#specifying-multiple-configurations
+# for specific requirements and details for the AWS provider.
+
+# resource "tfe_variable" "enable_aws_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_AWS_PROVIDER_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Workload Identity integration for AWS for an additional configuration named other_config."
+# }

--- a/azure/tfc-workspace.tf
+++ b/azure/tfc-workspace.tf
@@ -49,3 +49,28 @@ resource "tfe_variable" "tfc_azure_client_id" {
 
 #   description = "The value to use as the audience claim in run identity tokens"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#specifying-multiple-configurations
+# for specific requirements and details for the Azure provider.
+
+# resource "tfe_variable" "enable_azure_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_AZURE_PROVIDER_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Workload Identity integration for Azure for an additional configuration named other_config."
+# }

--- a/gcp/tfc-workspace.tf
+++ b/gcp/tfc-workspace.tf
@@ -99,3 +99,28 @@ resource "tfe_variable" "tfc_gcp_service_account_email" {
 
 #   description = "The value to use as the audience claim in run identity tokens"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration#specifying-multiple-configurations
+# for specific requirements and details for the GCP provider.
+
+# resource "tfe_variable" "enable_gcp_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_GCP_PROVIDER_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Workload Identity integration for GCP for an additional configuration named other_config."
+# }

--- a/vault-backed/aws/tfc-workspace.tf
+++ b/vault-backed/aws/tfc-workspace.tf
@@ -130,3 +130,28 @@ resource "tfe_variable" "tfc_aws_run_vault_role" {
 
 #   description = "The value to use as the audience claim in run identity tokens"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration#specifying-multiple-configurations
+# for specific requirements and details for Vault-backed AWS.
+
+# resource "tfe_variable" "enable_aws_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_VAULT_BACKED_AWS_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Vault Secrets Engine integration for AWS for an additional configuration named other_config."
+# }

--- a/vault-backed/azure/tfc-workspace.tf
+++ b/vault-backed/azure/tfc-workspace.tf
@@ -110,3 +110,28 @@ resource "tfe_variable" "tfc_azure_vault_namespace" {
 
 #   description = "The value to use as the audience claim in run identity tokens"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration#specifying-multiple-configurations
+# for specific requirements and details for Vault-backed Azure.
+
+# resource "tfe_variable" "enable_azure_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_VAULT_BACKED_AZURE_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Vault Secrets Engine integration for Azure for an additional configuration named other_config."
+# }

--- a/vault-backed/gcp/tfc-workspace.tf
+++ b/vault-backed/gcp/tfc-workspace.tf
@@ -120,3 +120,28 @@ resource "tfe_variable" "tfc_gcp_run_vault_roleset" {
 
 #   description = "The value to use as the audience claim in run identity tokens"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration#specifying-multiple-configurations
+# for specific requirements and details for Vault-backed GCP.
+
+# resource "tfe_variable" "enable_gcp_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_VAULT_BACKED_GCP_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Vault Secrets Engine integration for GCP for an additional configuration named other_config."
+# }

--- a/vault/tfc-workspace.tf
+++ b/vault/tfc-workspace.tf
@@ -93,3 +93,28 @@ resource "tfe_variable" "tfc_vault_role" {
 
 #   description = "A Base64 encoded CA certificate to use when authenticating with Vault"
 # }
+
+# The following is an example of the naming format used to define variables for
+# additional configurations. Additional required configuration values must also
+# be supplied in this same format, as well as any desired optional configuration
+# values.
+#
+# Additional configurations can be used to uniquely authenticate multiple aliases
+# of the same provider in a workspace, with different roles/permissions in different
+# accounts or regions.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations
+# for more details on specifying multiple configurations.
+#
+# See https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration#specifying-multiple-configurations
+# for specific requirements and details for the Vault provider.
+
+# resource "tfe_variable" "enable_vault_provider_auth_other_config" {
+#   workspace_id = tfe_workspace.my_workspace.id
+
+#   key      = "TFC_VAULT_PROVIDER_AUTH_other_config"
+#   value    = "true"
+#   category = "env"
+
+#   description = "Enable the Workload Identity integration for Vault for an additional configuration named other_config."
+# }


### PR DESCRIPTION
### Description
Adds example variable format to be used when specifying multiple configurations in the same workspace for each provider. 

Also adds documentation links to the appropriate top-level documentation page for specifying multiple configurations, as well as provider specific documentation pages for each provider.

### Links
- [AWS JIRA](https://hashicorp.atlassian.net/browse/TF-6190)
- [Azure JIRA](https://hashicorp.atlassian.net/browse/TF-6191)
- [GCP JIRA](https://hashicorp.atlassian.net/browse/TF-6192)
- [Vault JIRA](https://hashicorp.atlassian.net/browse/TF-6193)
- [Vault-backed AWS JIRA](https://hashicorp.atlassian.net/browse/TF-6194)
- [Vault-backed Azure JIRA](https://hashicorp.atlassian.net/browse/TF-6195)
- [Vault-backed GCP JIRA](https://hashicorp.atlassian.net/browse/TF-6196)