### PR TITLE
Use the configured Terraform Cloud project name to determine where to create a workspace

### DIFF
--- a/aws/tfc-workspace.tf
+++ b/aws/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to AWS with the permissions set in the AWS policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs

--- a/azure/tfc-workspace.tf
+++ b/azure/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to Azure with the permissions set in the Azure policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs

--- a/gcp/tfc-workspace.tf
+++ b/gcp/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to GCP with the permissions set in the GCP policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs

--- a/vault-backed/aws/tfc-workspace.tf
+++ b/vault-backed/aws/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to Vault with the permissions set in the Vault policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs

--- a/vault-backed/azure/tfc-workspace.tf
+++ b/vault-backed/azure/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to Vault with the permissions set in the Vault policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs

--- a/vault-backed/gcp/tfc-workspace.tf
+++ b/vault-backed/gcp/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to Vault with the permissions set in the Vault policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs

--- a/vault/tfc-workspace.tf
+++ b/vault/tfc-workspace.tf
@@ -5,6 +5,14 @@ provider "tfe" {
   hostname = var.tfc_hostname
 }
 
+# Data source used to grab the project under which a workspace will be created.
+#
+# https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project
+data "tfe_project" "tfc_project" {
+  name = var.tfc_project_name
+  organization = var.tfc_organization_name
+}
+
 # Runs in this workspace will be automatically authenticated
 # to Vault with the permissions set in the Vault policy.
 #
@@ -12,6 +20,7 @@ provider "tfe" {
 resource "tfe_workspace" "my_workspace" {
   name         = var.tfc_workspace_name
   organization = var.tfc_organization_name
+  project_id   = data.tfe_project.tfc_project.id
 }
 
 # The following variables must be set to allow runs


### PR DESCRIPTION
Thanks for these examples 👍 

I found it confusing that the `tfc_project_name` variable is declared but that when I overrode its default value in my `terraform.tfvars` the workspace was still created in the project named "Default Project". This PR addresses the problem.