### PR TITLE
Add policy to allow Vault user to rotate its own creds; other small improvements

### DIFF
--- a/vault-backed/aws/vars.tf
+++ b/vault-backed/aws/vars.tf
@@ -37,7 +37,7 @@ variable "tfc_workspace_name" {
 
 variable "vault_url" {
   type        = string
-  description = "The URL of the Vault instance you'd like to use with Terraform Cloud."
+  description = "The URL of the Vault instance you'd like to use with Terraform Cloud"
 }
 
 variable "jwt_backend_path" {

--- a/vault-backed/aws/vars.tf
+++ b/vault-backed/aws/vars.tf
@@ -37,7 +37,7 @@ variable "tfc_workspace_name" {
 
 variable "vault_url" {
   type        = string
-  description = "The URL of the Vault instance you'd like to use with Terraform Cloud"
+  description = "The URL of the Vault instance you'd like to use with Terraform Cloud. Can also be set via VAULT_ADDR environment variable."
 }
 
 variable "jwt_backend_path" {

--- a/vault-backed/aws/vars.tf
+++ b/vault-backed/aws/vars.tf
@@ -37,7 +37,7 @@ variable "tfc_workspace_name" {
 
 variable "vault_url" {
   type        = string
-  description = "The URL of the Vault instance you'd like to use with Terraform Cloud. Can also be set via VAULT_ADDR environment variable."
+  description = "The URL of the Vault instance you'd like to use with Terraform Cloud."
 }
 
 variable "jwt_backend_path" {

--- a/vault-backed/aws/vault.tf
+++ b/vault-backed/aws/vault.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "vault" {
-  # address = var.vault_url
+  address = var.vault_url
 }
 
 # Enables the jwt auth backend in Vault at the given path,

--- a/vault-backed/aws/vault.tf
+++ b/vault-backed/aws/vault.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "vault" {
-  address = var.vault_url
+  # address = var.vault_url
 }
 
 # Enables the jwt auth backend in Vault at the given path,
@@ -10,6 +10,7 @@ provider "vault" {
 #
 # https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/jwt_auth_backend
 resource "vault_jwt_auth_backend" "tfc_jwt" {
+  namespace          = var.vault_namespace
   path               = var.jwt_backend_path
   type               = "jwt"
   oidc_discovery_url = "https://${var.tfc_hostname}"
@@ -43,7 +44,8 @@ resource "vault_jwt_auth_backend_role" "tfc_role" {
 #
 # https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy
 resource "vault_policy" "tfc_policy" {
-  name = "tfc-policy"
+  namespace = var.vault_namespace
+  name      = "tfc-policy"
 
   policy = <<EOT
 # Allow tokens to query themselves
@@ -88,6 +90,7 @@ resource "vault_aws_secret_backend" "aws_secret_backend" {
 #
 # https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/aws_secret_backend_role
 resource "vault_aws_secret_backend_role" "aws_secret_backend_role" {
+  namespace       = var.vault_namespace
   backend         = vault_aws_secret_backend.aws_secret_backend.path
   name            = var.aws_secret_backend_role_name
   credential_type = "assumed_role"


### PR DESCRIPTION
1. There was an extraneous assume role permission - it's only needed in one place (either on the role, referencing the user, or the reverse, doesn't need both).
2. Added the minimal set of permissions needed for the user to rotate its own access keys
3. A few of the Vault resources were missing the Namespace

I tested this locally, can see the results here - https://gist.github.com/nphilbrook/92bfbf04c41f35026d8261f15700e9d5

Also actually used the HCP TF workspace to use the perms and it also worked :tada: 